### PR TITLE
Added ability to disable TrafficStopYield

### DIFF
--- a/Custom-Pullover/Custom Pullover.csproj
+++ b/Custom-Pullover/Custom Pullover.csproj
@@ -70,6 +70,9 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="LSPD First Response">
+      <HintPath>..\..\Documents\LSPDFR\Dev\LSPD First Response.dll</HintPath>
+    </Reference>
     <Reference Include="LSPD First Response, Version=0.4.7297.8062, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\SteamStuff\Mod development\_External references\LSPD First Response.dll</HintPath>
@@ -81,6 +84,9 @@
     <Reference Include="RAGENativeUI, Version=1.6.3.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\SteamStuff\Mod development\_External references\RAGENativeUI.dll</HintPath>
+    </Reference>
+    <Reference Include="RagePluginHook, Version=0.0.0.0, Culture=neutral, processorArchitecture=Amd64">
+      <HintPath>packages\RagePluginHook.1.109.1\lib\net472\RagePluginHook.dll</HintPath>
     </Reference>
     <Reference Include="RagePluginHookSDK, Version=0.0.0.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
@@ -105,6 +111,9 @@
   </ItemGroup>
   <ItemGroup>
     <WCFMetadata Include="Service References\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/Custom-Pullover/CustomPulloverHandler.cs
+++ b/Custom-Pullover/CustomPulloverHandler.cs
@@ -4,42 +4,61 @@ using LSPD_First_Response.Mod.API;
 using System.Windows.Forms;
 using System.Reflection;
 
-[assembly: Rage.Attributes.Plugin("Custom Pullover", Description = "INSTALL IN PLUGINS/LSPDFR", Author = "Waynieoaks")]
+[assembly:
+    Rage.Attributes.Plugin("Custom Pullover", Description = "INSTALL IN PLUGINS/LSPDFR",
+        Author = "Waynieoaks")]
+
 namespace Custom_Pullover
 {
     public class EntryPoint
     {
         public static void Main()
         {
-            Game.DisplayNotification("You have installed Custom Pullover incorrectly and in the wrong folder: you must install it in Plugins/LSPDFR. It will then be automatically loaded when going on duty - you must NOT load it yourself via RAGEPluginHook.");
+            Game.DisplayNotification(
+                "You have installed Custom Pullover incorrectly and in the wrong folder: you must install it in Plugins/LSPDFR. It will then be automatically loaded when going on duty - you must NOT load it yourself via RAGEPluginHook.");
             return;
         }
     }
 
     internal class CustomPulloverHandler
     {
-
         private static void LoadValuesFromIniFile()
         {
             try
             {
                 TrafficStopFollowKey = (Keys)kc.ConvertFromString(GetTrafficStopFollowKey());
-                TrafficStopFollowModifierKey = (Keys)kc.ConvertFromString(GetTrafficStopFollowModifierKey());
-                TrafficStopMimicKey = (Keys)kc.ConvertFromString(InitialiseFile().ReadString("Keybindings", "TrafficStopMimicKey"));
-                TrafficStopMimicModifierKey = (Keys)kc.ConvertFromString(InitialiseFile().ReadString("Keybindings", "TrafficStopMimicModifierKey"));
-                IniDefaults.PositionUpKey = (Keys)kc.ConvertFromString(InitialiseFile().ReadString("Keybindings", "PositionUpKey", "NumPad9"));
-                IniDefaults.PositionRightKey = (Keys)kc.ConvertFromString(InitialiseFile().ReadString("Keybindings", "PositionRightKey", "NumPad6"));
-                IniDefaults.PositionResetKey = (Keys)kc.ConvertFromString(InitialiseFile().ReadString("Keybindings", "PositionResetKey", "NumPad5"));
-                IniDefaults.PositionLeftKey = (Keys)kc.ConvertFromString(InitialiseFile().ReadString("Keybindings", "PositionLeftKey", "NumPad4"));
-                IniDefaults.PositionForwardKey = (Keys)kc.ConvertFromString(InitialiseFile().ReadString("Keybindings", "PositionForwardKey", "NumPad8"));
-                IniDefaults.PositionDownKey = (Keys)kc.ConvertFromString(InitialiseFile().ReadString("Keybindings", "PositionDownKey", "NumPad3"));
-                IniDefaults.PositionBackwardKey = (Keys)kc.ConvertFromString(InitialiseFile().ReadString("Keybindings", "PositionBackwardKey", "NumPad2"));
-                TrafficStopAssist.VehicleDoorLockDistance = InitialiseFile().ReadSingle("Features", "VehicleDoorLockDistance", 5.2f);
-                TrafficStopAssist.VehicleDoorUnlockDistance = InitialiseFile().ReadSingle("Features", "VehicleDoorUnlockDistance", 3.5f);
-                AutoVehicleDoorLock = InitialiseFile().ReadBoolean("Features", "AutoVehicleDoorLock", true);
-                TrafficStopAIYieldEnabled = InitialiseFile().ReadBoolean("Features", "TrafficStopAIYieldEnabled", false);
-                CustomPulloverLocationKey = (Keys)kc.ConvertFromString(InitialiseFile().ReadString("Keybindings", "CustomPulloverLocationKey", "W"));
-                CustomPulloverLocationModifierKey = (Keys)kc.ConvertFromString(InitialiseFile().ReadString("Keybindings", "CustomPulloverLocationModifierKey", "LControlKey"));
+                TrafficStopFollowModifierKey =
+                    (Keys)kc.ConvertFromString(GetTrafficStopFollowModifierKey());
+                TrafficStopMimicKey = (Keys)kc.ConvertFromString(InitialiseFile()
+                    .ReadString("Keybindings", "TrafficStopMimicKey"));
+                TrafficStopMimicModifierKey = (Keys)kc.ConvertFromString(InitialiseFile()
+                    .ReadString("Keybindings", "TrafficStopMimicModifierKey"));
+                IniDefaults.PositionUpKey = (Keys)kc.ConvertFromString(InitialiseFile()
+                    .ReadString("Keybindings", "PositionUpKey", "NumPad9"));
+                IniDefaults.PositionRightKey = (Keys)kc.ConvertFromString(InitialiseFile()
+                    .ReadString("Keybindings", "PositionRightKey", "NumPad6"));
+                IniDefaults.PositionResetKey = (Keys)kc.ConvertFromString(InitialiseFile()
+                    .ReadString("Keybindings", "PositionResetKey", "NumPad5"));
+                IniDefaults.PositionLeftKey = (Keys)kc.ConvertFromString(InitialiseFile()
+                    .ReadString("Keybindings", "PositionLeftKey", "NumPad4"));
+                IniDefaults.PositionForwardKey = (Keys)kc.ConvertFromString(InitialiseFile()
+                    .ReadString("Keybindings", "PositionForwardKey", "NumPad8"));
+                IniDefaults.PositionDownKey = (Keys)kc.ConvertFromString(InitialiseFile()
+                    .ReadString("Keybindings", "PositionDownKey", "NumPad3"));
+                IniDefaults.PositionBackwardKey = (Keys)kc.ConvertFromString(InitialiseFile()
+                    .ReadString("Keybindings", "PositionBackwardKey", "NumPad2"));
+                TrafficStopAssist.VehicleDoorLockDistance = InitialiseFile()
+                    .ReadSingle("Features", "VehicleDoorLockDistance", 5.2f);
+                TrafficStopAssist.VehicleDoorUnlockDistance = InitialiseFile()
+                    .ReadSingle("Features", "VehicleDoorUnlockDistance", 3.5f);
+                AutoVehicleDoorLock =
+                    InitialiseFile().ReadBoolean("Features", "AutoVehicleDoorLock", true);
+                TrafficStopAIYieldEnabled = InitialiseFile()
+                    .ReadBoolean("Features", "TrafficStopAIYieldEnabled", false);
+                CustomPulloverLocationKey = (Keys)kc.ConvertFromString(InitialiseFile()
+                    .ReadString("Keybindings", "CustomPulloverLocationKey", "W"));
+                CustomPulloverLocationModifierKey = (Keys)kc.ConvertFromString(InitialiseFile()
+                    .ReadString("Keybindings", "CustomPulloverLocationModifierKey", "LControlKey"));
             }
             catch (Exception e)
             {
@@ -48,17 +67,21 @@ namespace Custom_Pullover
                 TrafficStopMimicKey = Keys.R;
                 TrafficStopMimicModifierKey = Keys.LControlKey;
                 Game.LogTrivial(e.ToString());
-                Game.LogTrivial("Loading default Custom Pullover INI file - Error detected in user's INI file.");
-                Game.DisplayNotification("~r~~h~Error~s~ reading Custom Pullover ini file. Default values set; replace with default INI file!");
+                Game.LogTrivial(
+                    "Loading default Custom Pullover INI file - Error detected in user's INI file.");
+                Game.DisplayNotification(
+                    "~r~~h~Error~s~ reading Custom Pullover ini file. Default values set; replace with default INI file!");
             }
-
         }
+
         public static Keys CustomPulloverLocationKey = Keys.W;
         public static Keys CustomPulloverLocationModifierKey = Keys.LControlKey;
         public static Keys TrafficStopMimicModifierKey { get; set; }
         public static KeysConverter kc = new KeysConverter();
         public static Keys TrafficStopFollowModifierKey { get; set; }
+
         public static Keys TrafficStopFollowKey { get; set; }
+
         // private static Keys parkModifierKey { get; set; }
         public static bool IsSomeoneRunningTheLight { get; set; }
         public static bool IsSomeoneFollowing { get; set; }
@@ -70,7 +93,7 @@ namespace Custom_Pullover
         internal static void MainLoop()
         {
             Game.LogTrivial("Custom Pullover.Mainloop started");
-            
+
             Game.LogTrivial("Loading Custom Pullover settings...");
             LoadValuesFromIniFile();
 
@@ -84,8 +107,9 @@ namespace Custom_Pullover
                     GameFiber.Yield();
                     if (Functions.IsPlayerPerformingPullover())
                     {
-
-                        if (ExtensionMethods.IsKeyDownRightNowComputerCheck(TrafficStopFollowModifierKey) || (TrafficStopFollowModifierKey == Keys.None))
+                        if (ExtensionMethods.IsKeyDownRightNowComputerCheck(
+                                TrafficStopFollowModifierKey) ||
+                            (TrafficStopFollowModifierKey == Keys.None))
                         {
                             if (ExtensionMethods.IsKeyDownComputerCheck(TrafficStopFollowKey))
                             {
@@ -93,10 +117,16 @@ namespace Custom_Pullover
                                 {
                                     TrafficStopAssist.FollowMe();
                                 }
-                                else { IsSomeoneFollowing = false; }
+                                else
+                                {
+                                    IsSomeoneFollowing = false;
+                                }
                             }
                         }
-                        if (ExtensionMethods.IsKeyDownRightNowComputerCheck(TrafficStopMimicModifierKey) || (TrafficStopMimicModifierKey == Keys.None))
+
+                        if (ExtensionMethods.IsKeyDownRightNowComputerCheck(
+                                TrafficStopMimicModifierKey) ||
+                            (TrafficStopMimicModifierKey == Keys.None))
                         {
                             if (ExtensionMethods.IsKeyDownComputerCheck(TrafficStopMimicKey))
                             {
@@ -110,7 +140,10 @@ namespace Custom_Pullover
                                 }
                             }
                         }
-                        if (ExtensionMethods.IsKeyDownRightNowComputerCheck(CustomPulloverLocationModifierKey) || (CustomPulloverLocationModifierKey == Keys.None))
+
+                        if (ExtensionMethods.IsKeyDownRightNowComputerCheck(
+                                CustomPulloverLocationModifierKey) ||
+                            (CustomPulloverLocationModifierKey == Keys.None))
                         {
                             if (ExtensionMethods.IsKeyDownComputerCheck(CustomPulloverLocationKey))
                             {
@@ -130,47 +163,56 @@ namespace Custom_Pullover
                             TrafficStopAssist.CheckForceRedLightRun();
                         }
                     }
+
+                    if (TrafficStopAIYieldEnabled)
+                    {
+                        TrafficStopAssist.CheckForYieldDisable();
+                    }
+
+                    if (AutoVehicleDoorLock)
+                    {
+                        TrafficStopAssist.LockPlayerDoors();
+                    }
                 }
             });
-
-            while (true)
-            {
-                GameFiber.Yield();
-                if (TrafficStopAIYieldEnabled)
-                {
-                    TrafficStopAssist.CheckForYieldDisable();
-                }
-
-                if (AutoVehicleDoorLock)
-                {
-                    TrafficStopAssist.LockPlayerDoors();
-                }
-
-                //VehicleDetails.CheckForTextEntry();
-            }
-
         }
+
         public static bool IsLSPDFRPluginRunning(string Plugin, Version minversion = null)
         {
             foreach (Assembly assembly in Functions.GetAllUserPlugins())
             {
-                AssemblyName an = assembly.GetName(); if (an.Name.ToLower() == Plugin.ToLower())
+                AssemblyName an = assembly.GetName();
+                if (an.Name.ToLower() == Plugin.ToLower())
                 {
-                    if (minversion == null || an.Version.CompareTo(minversion) >= 0) { return true; }
+                    if (minversion == null || an.Version.CompareTo(minversion) >= 0)
+                    {
+                        return true;
+                    }
                 }
             }
+
             return false;
         }
 
-        public static Assembly LSPDFRResolveEventHandler(object sender, ResolveEventArgs args) { foreach (Assembly assembly in Functions.GetAllUserPlugins()) { if (args.Name.ToLower().Contains(assembly.GetName().Name.ToLower())) { return assembly; } } return null; }
+        public static Assembly LSPDFRResolveEventHandler(object sender, ResolveEventArgs args)
+        {
+            foreach (Assembly assembly in Functions.GetAllUserPlugins())
+            {
+                if (args.Name.ToLower().Contains(assembly.GetName().Name.ToLower()))
+                {
+                    return assembly;
+                }
+            }
+
+            return null;
+        }
 
         public static InitializationFile InitialiseFile()
         {
             InitializationFile ini = new InitializationFile("Plugins/LSPDFR/Custom Pullover.ini");
             ini.Create();
-           // Game.LogTrivial("Custom Pullover: Reading INI file.");
+            // Game.LogTrivial("Custom Pullover: Reading INI file.");
             return ini;
-        
         }
 
         private static string GetTrafficStopFollowKey()
@@ -179,24 +221,29 @@ namespace Custom_Pullover
             string key = ini.ReadString("Keybindings", "TrafficStopFollowKey", "T");
             return key;
         }
+
         private static string GetTrafficStopFollowModifierKey()
         {
             InitializationFile ini = InitialiseFile();
-            string key = ini.ReadString("Keybindings", "TrafficStopFollowModifierKey", "LControlKey");
+            string key = ini.ReadString("Keybindings", "TrafficStopFollowModifierKey",
+                "LControlKey");
             return key;
         }
-        
+
         internal static void Initialise()
         {
-            AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(LSPDFRResolveEventHandler);
-            
+            AppDomain.CurrentDomain.AssemblyResolve +=
+                new ResolveEventHandler(LSPDFRResolveEventHandler);
+
             GameFiber.StartNew(delegate
             {
-                Game.LogTrivial("Custom Pullover has been loaded successfully! [CustomPulloverHandler.cs-201]");
+                Game.LogTrivial(
+                    "Custom Pullover has been loaded successfully! [CustomPulloverHandler.cs-201]");
                 GameFiber.Wait(6000);
-                Game.DisplayNotification("~b~Custom Pullover~b~ " + Assembly.GetExecutingAssembly().GetName().Version.ToString() );
+                Game.DisplayNotification("~b~Custom Pullover~b~ " +
+                                         Assembly.GetExecutingAssembly().GetName().Version
+                                             .ToString());
                 MainLoop();
-                
             });
         }
     }

--- a/Custom-Pullover/CustomPulloverHandler.cs
+++ b/Custom-Pullover/CustomPulloverHandler.cs
@@ -37,6 +37,7 @@ namespace Custom_Pullover
                 TrafficStopAssist.VehicleDoorLockDistance = InitialiseFile().ReadSingle("Features", "VehicleDoorLockDistance", 5.2f);
                 TrafficStopAssist.VehicleDoorUnlockDistance = InitialiseFile().ReadSingle("Features", "VehicleDoorUnlockDistance", 3.5f);
                 AutoVehicleDoorLock = InitialiseFile().ReadBoolean("Features", "AutoVehicleDoorLock", true);
+                TrafficStopAIYieldEnabled = InitialiseFile().ReadBoolean("Features", "TrafficStopAIYieldEnabled", false);
                 CustomPulloverLocationKey = (Keys)kc.ConvertFromString(InitialiseFile().ReadString("Keybindings", "CustomPulloverLocationKey", "W"));
                 CustomPulloverLocationModifierKey = (Keys)kc.ConvertFromString(InitialiseFile().ReadString("Keybindings", "CustomPulloverLocationModifierKey", "LControlKey"));
             }
@@ -64,6 +65,7 @@ namespace Custom_Pullover
         public static Keys TrafficStopMimicKey { get; set; }
 
         public static bool AutoVehicleDoorLock = true;
+        public static bool TrafficStopAIYieldEnabled = false;
 
         internal static void MainLoop()
         {
@@ -134,7 +136,11 @@ namespace Custom_Pullover
             while (true)
             {
                 GameFiber.Yield();
-                TrafficStopAssist.CheckForYieldDisable();
+                if (TrafficStopAIYieldEnabled)
+                {
+                    TrafficStopAssist.CheckForYieldDisable();
+                }
+
                 if (AutoVehicleDoorLock)
                 {
                     TrafficStopAssist.LockPlayerDoors();

--- a/Custom-Pullover/Properties/AssemblyInfo.cs
+++ b/Custom-Pullover/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.1")]
-[assembly: AssemblyFileVersion("1.1.0.1")]
+[assembly: AssemblyVersion("1.1.0.2")]
+[assembly: AssemblyFileVersion("1.1.0.2")]


### PR DESCRIPTION
I saw that you were setting the variable `ShouldVehiclesYieldToThisVehicle` to true whenever the player was not on a pullover. This was messing up with a plugin I was trying to make to help the AI vehicles be better when the user is running lights and sirens. I thought instead of just fully disabling it, I would make it toggleable through the INI. 

I also updated the version number. If you could release it on [the FR site](https://www.lcpdfr.com), that would make my life easier so I do not have to release my own version. 😄 

Thank you for your time.